### PR TITLE
First chunk had an invalid massive duration after a stop-start

### DIFF
--- a/KalturaWowzaServer/src/main/java/com/kaltura/media/server/wowza/CuePointsManager.java
+++ b/KalturaWowzaServer/src/main/java/com/kaltura/media/server/wowza/CuePointsManager.java
@@ -324,7 +324,10 @@ public class CuePointsManager extends KalturaManager implements IKalturaEventCon
 		data.put(OFFSET_KEY, offset);
 		data.put(TIMESTAMP_KEY, time);
 
-		stream.sendDirect(CuePointsManager.PUBLIC_METADATA, data);
+		//This condition is due to huge duration time (invalid) in the first chunk after stop-start on FMLE.
+		if (stream.getPlayPackets().size() > 0) {
+			stream.sendDirect(CuePointsManager.PUBLIC_METADATA, data);
+		}
 		logger.info("Sent sync-point: stream " + stream.getName() + "time: " + time + " offset: " + offset + "id: " + id);
 	}
 }


### PR DESCRIPTION
After preforming stop-start on FMLE, first chunk has a massive invalid duration.

Fix: Before calling sendDriect() method, make sure stream has started receiving packets.